### PR TITLE
align the stack

### DIFF
--- a/Windows/00_BasicOS/00_pe_return_00.asm
+++ b/Windows/00_BasicOS/00_pe_return_00.asm
@@ -8,7 +8,7 @@ include 'win64a.inc'
 
 section '.code' code readable executable 
 start: 
-
+  sub rsp, 8
   mov eax, 42
 
   exit:


### PR DESCRIPTION
When I execute the example program ([return 42](https://github.com/macton/x64-fasm-examples/blob/master/Windows/00_BasicOS/00_pe_return_00.asm)) on Windows 11, it crashes with a SIGSEGV.

I tried debugging it with GDB from MSYS2, and it crashes at KERNELBASE!CreateThreadpoolTimer, but I still have no idea what’s going on.

I tested it on Windows 7, and it runs fine using the same FASM executable and the same example code without modification. So, I started searching for a solution online and found [this post](https://board.flatassembler.net/topic.php?p=214216#214216).

It turns out the issue was due to a misalignment problem. Hopefully, this fix helps other novices like me who struggle with this error.